### PR TITLE
Use Gradle Module Data for tasks and dirs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,8 +14,13 @@ repositories {
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
     version.set("2023.3")
-    plugins.set(listOf("Kotlin", "java", "gradle"))
-
+    plugins.set(
+        listOf(
+            "org.jetbrains.kotlin",
+            "com.intellij.gradle",
+            "com.intellij.java",
+        )
+    )
     tasks {
         buildSearchableOptions {
             enabled = false

--- a/src/main/kotlin/com/getyourguide/paparazzi/Utils.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/Utils.kt
@@ -1,33 +1,51 @@
 package com.getyourguide.paparazzi
 
 import com.getyourguide.paparazzi.service.Snapshot
+import com.intellij.lang.jvm.annotation.JvmAnnotationClassValue
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.editor.CaretModel
+import com.intellij.openapi.externalSystem.model.DataNode
+import com.intellij.openapi.externalSystem.model.project.ModuleData
+import com.intellij.openapi.externalSystem.model.project.ProjectData
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.modules
 import com.intellij.openapi.project.rootManager
+import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiClassOwner
+import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
 import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.impl.source.PsiClassReferenceType
+import com.intellij.psi.util.PsiTypesUtil
 import com.intellij.util.concurrency.AppExecutorUtil
+import org.jetbrains.kotlin.asJava.elements.KtLightPsiClassObjectAccessExpression
+import org.jetbrains.kotlin.asJava.elements.KtLightPsiNameValuePair
+import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.idea.util.projectStructure.getModule
-import org.jetbrains.kotlin.idea.util.projectStructure.getModuleDir
+import org.jetbrains.kotlin.idea.util.projectStructure.module
 import org.jetbrains.kotlin.psi.psiUtil.parents
+import org.jetbrains.plugins.gradle.util.GradleUtil
 import org.jetbrains.uast.UClass
 import org.jetbrains.uast.UMethod
-import org.jetbrains.uast.getContainingUFile
 import org.jetbrains.uast.toUElement
 import java.io.File
 import java.util.concurrent.Callable
 
 private const val PAPARAZZI_IMPORT = "app.cash.paparazzi.Paparazzi"
+private const val PARAMETRIZED_CLASS_NAME = "org.junit.runners.Parameterized"
+private const val RUN_WITH_CLASS_NAME = "org.junit.runner.RunWith"
+private const val TEST_PARAM_INJECTOR_CLASS_NAME =
+    "com.google.testing.junit.testparameterinjector.TestParameterInjector"
 
 internal fun VirtualFile.toSnapshots(project: Project, isFailure: Boolean): List<Snapshot> {
     val psiFile = PsiManager.getInstance(project).findFile(this) as? PsiClassOwner
@@ -61,12 +79,48 @@ internal fun VirtualFile.methods(project: Project): List<String> {
 }
 
 internal fun Project.modulePath(file: VirtualFile): String? {
-    return modules.asSequence().map { it.getModuleDir() }.firstOrNull { file.path.startsWith(it) }
-        ?: basePath?.let { projectPath ->
-            val relativePath = FileUtil.getRelativePath(projectPath, file.path, File.separatorChar)
-            val moduleName = relativePath?.split(File.separator)?.firstOrNull()
-            if (moduleName != null) projectPath + File.separator + moduleName else null
+    return gradleModuleData(file)?.data?.linkedExternalProjectPath ?: basePath?.let { projectPath ->
+        val relativePath = FileUtil.getRelativePath(projectPath, file.path, File.separatorChar)
+        val moduleName = relativePath?.split(File.separator)?.firstOrNull()
+        if (moduleName != null) projectPath + File.separator + moduleName else null
+    }
+}
+
+@Suppress("UnstableApiUsage")
+internal fun Project.gradleModuleData(
+    file: VirtualFile,
+): DataNode<ModuleData>? {
+    return file.getModule(this)?.let { module ->
+        return GradleUtil.findGradleModuleData(module)
+    }
+}
+
+@Suppress("UnstableApiUsage")
+internal fun gradleModuleData(
+    dir: PsiDirectory,
+): DataNode<ModuleData>? {
+    return dir.module?.let { module ->
+        return GradleUtil.findGradleModuleData(module)
+    }
+}
+
+internal fun DataNode<ModuleData>.getProjectPath(): String? {
+    val parent = parent
+    return if (parent != null) {
+        when (val data = parent.data) {
+            is ModuleData -> {
+                (parent as DataNode<ModuleData>).getProjectPath()
+            }
+
+            is ProjectData -> {
+                data.ideProjectFileDirectoryPath
+            }
+
+            else -> null
         }
+    } else {
+        data.linkedExternalProjectPath
+    }
 }
 
 internal inline fun <reified T> nonBlocking(crossinline asyncAction: () -> T, crossinline uiThreadAction: (T) -> Unit) {
@@ -78,25 +132,38 @@ internal inline fun <reified T> nonBlocking(crossinline asyncAction: () -> T, cr
 }
 
 internal fun UClass.isPaparazziClass(): Boolean {
-    if (hasImport(PAPARAZZI_IMPORT)) {
-        return true
-    } else {
-        javaPsi.supers.forEach { psiClass ->
-            if ((psiClass.toUElement() as? UClass)?.hasImport(PAPARAZZI_IMPORT) == true) {
-                return true
-            }
-        }
+    return fields.any { field -> field.isPaparazziField() } || supers.any { superClass ->
+        superClass.fields.any { field -> field.isPaparazziField() }
     }
-    return false
-}
-
-internal fun UClass.hasImport(packageName: String): Boolean {
-    val uFile = getContainingUFile()
-    return uFile?.imports?.find { it.asSourceString().contains(packageName) } != null
 }
 
 internal fun PsiElement.containingUClass(): UClass? {
     return (parents.toList().map { it.toUElement() }.find { it is UClass } as? UClass)
+}
+
+internal fun isParametrizedTest(
+    psiClass: PsiClass,
+    psiMethod: PsiMethod?,
+): Boolean {
+    if (psiMethod != null && psiMethod.hasParameters()) {
+        // Most likely it uses some parametrization
+        return true
+    }
+    val annotation = psiClass.annotations.find {
+        RUN_WITH_CLASS_NAME == it.qualifiedName
+    } ?: return false
+    val pair = annotation.attributes.find { it.attributeName == "value" } ?: return false
+    val qualifiedName = if (psiClass.language is KotlinLanguage) {
+        val kotlinPair = pair as KtLightPsiNameValuePair
+        val runnerClass = kotlinPair.value as KtLightPsiClassObjectAccessExpression
+        val runnerType = runnerClass.type as PsiClassReferenceType
+        runnerType.reference.qualifiedName
+
+    } else {
+        val classValue = pair.attributeValue as JvmAnnotationClassValue
+        classValue.qualifiedName
+    }
+    return PARAMETRIZED_CLASS_NAME == qualifiedName || TEST_PARAM_INJECTOR_CLASS_NAME == qualifiedName
 }
 
 private fun PsiClassOwner.toSnapshots(snapshots: List<VirtualFile>, isFailure: Boolean): List<Snapshot> {
@@ -139,4 +206,19 @@ private fun Project.failureDiffSnapshots(file: VirtualFile): List<VirtualFile> {
             it.findChild("out")?.findChild("failures")?.children?.toList() ?: emptyList()
         } ?: emptyList()
     } else emptyList()
+}
+
+private fun Module.hasFile(
+    file: VirtualFile,
+): Boolean =
+    ModuleRootManager.getInstance(this)
+        .sourceRoots
+        .any { root -> file.path.startsWith(root.path) }
+
+private fun PsiField.isPaparazziField(): Boolean {
+    val psiClass = PsiTypesUtil.getPsiClass(type)
+    return PAPARAZZI_IMPORT == psiClass?.qualifiedName ||
+            psiClass?.supers?.any { parentClass ->
+                PAPARAZZI_IMPORT == parentClass.qualifiedName
+            } == true
 }

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/RecordPaparazziAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/RecordPaparazziAction.kt
@@ -1,6 +1,7 @@
 package com.getyourguide.paparazzi.actions
 
 import com.getyourguide.paparazzi.file
+import com.getyourguide.paparazzi.getModuleId
 import com.getyourguide.paparazzi.getProjectPath
 import com.getyourguide.paparazzi.gradleModuleData
 import com.getyourguide.paparazzi.markers.getQualifiedTestName
@@ -31,14 +32,20 @@ class RecordPaparazziAction(private val psiClass: PsiClass, private val psiMetho
         val file = psiClass.file() ?: return
         val gradleData = project.gradleModuleData(file) ?: return
         val path = gradleData.getProjectPath() ?: project.basePath ?: return
+        val moduleId = gradleData.getModuleId()
         val testName = getQualifiedTestName(psiClass, psiMethod)
-        val gradleCommand = "${gradleData.data.id}:${project.service.settings.recordSnapshotsCommand}"
+        val task = project.service.settings.recordSnapshotsCommand
         val scriptParams = project.service.settings.recordScriptParams
         val filters = if (testName != null) "--tests $testName" else ""
+        val command = if (moduleId != null) {
+            "$moduleId:$task $filters"
+        } else {
+            "$task $filters"
+        }.trim()
         runGradle(
             project,
             path,
-            "$gradleCommand $filters",
+            command,
             scriptParams,
             RecordTaskCallback(project, psiClass, psiMethod)
         )

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/RecordPaparazziAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/RecordPaparazziAction.kt
@@ -1,9 +1,10 @@
 package com.getyourguide.paparazzi.actions
 
 import com.getyourguide.paparazzi.file
+import com.getyourguide.paparazzi.getProjectPath
+import com.getyourguide.paparazzi.gradleModuleData
 import com.getyourguide.paparazzi.markers.getQualifiedTestName
 import com.getyourguide.paparazzi.markers.runGradle
-import com.getyourguide.paparazzi.modulePath
 import com.getyourguide.paparazzi.service.service
 import com.intellij.icons.AllIcons.Debugger.Db_set_breakpoint
 import com.intellij.openapi.actionSystem.AnAction
@@ -28,14 +29,15 @@ class RecordPaparazziAction(private val psiClass: PsiClass, private val psiMetho
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val file = psiClass.file() ?: return
-        val modulePath = project.modulePath(file) ?: return
+        val gradleData = project.gradleModuleData(file) ?: return
+        val path = gradleData.getProjectPath() ?: project.basePath ?: return
         val testName = getQualifiedTestName(psiClass, psiMethod)
-        val gradleCommand = project.service.settings.recordSnapshotsCommand
+        val gradleCommand = "${gradleData.data.id}:${project.service.settings.recordSnapshotsCommand}"
         val scriptParams = project.service.settings.recordScriptParams
         val filters = if (testName != null) "--tests $testName" else ""
         runGradle(
             project,
-            modulePath,
+            path,
             "$gradleCommand $filters",
             scriptParams,
             RecordTaskCallback(project, psiClass, psiMethod)

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/VerifyPaparazziAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/VerifyPaparazziAction.kt
@@ -1,9 +1,10 @@
 package com.getyourguide.paparazzi.actions
 
 import com.getyourguide.paparazzi.file
+import com.getyourguide.paparazzi.getProjectPath
+import com.getyourguide.paparazzi.gradleModuleData
 import com.getyourguide.paparazzi.markers.getQualifiedTestName
 import com.getyourguide.paparazzi.markers.runGradle
-import com.getyourguide.paparazzi.modulePath
 import com.getyourguide.paparazzi.nonBlocking
 import com.getyourguide.paparazzi.service.service
 import com.getyourguide.paparazzi.service.toFileInfo
@@ -31,14 +32,15 @@ class VerifyPaparazziAction(private val psiClass: PsiClass, private val psiMetho
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val file = psiClass.file() ?: return
-        val modulePath = project.modulePath(file) ?: return
+        val gradleData = project.gradleModuleData(file) ?: return
+        val path = gradleData.getProjectPath() ?: project.basePath ?: return
         val testName = getQualifiedTestName(psiClass, psiMethod)
         val param = if (testName != null) "--tests $testName" else ""
-        val gradleCommand = project.service.settings.verifySnapshotsCommand
+        val gradleCommand = "${gradleData.data.id}:${project.service.settings.verifySnapshotsCommand}"
         val scriptParams = project.service.settings.verifyScriptParams
         runGradle(
             project,
-            modulePath,
+            path,
             "$gradleCommand $param",
             scriptParams,
             VerifyTaskCallback(project, psiClass, psiMethod)

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/VerifyPaparazziAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/VerifyPaparazziAction.kt
@@ -1,6 +1,7 @@
 package com.getyourguide.paparazzi.actions
 
 import com.getyourguide.paparazzi.file
+import com.getyourguide.paparazzi.getModuleId
 import com.getyourguide.paparazzi.getProjectPath
 import com.getyourguide.paparazzi.gradleModuleData
 import com.getyourguide.paparazzi.markers.getQualifiedTestName
@@ -34,14 +35,20 @@ class VerifyPaparazziAction(private val psiClass: PsiClass, private val psiMetho
         val file = psiClass.file() ?: return
         val gradleData = project.gradleModuleData(file) ?: return
         val path = gradleData.getProjectPath() ?: project.basePath ?: return
+        val moduleId = gradleData.getModuleId()
         val testName = getQualifiedTestName(psiClass, psiMethod)
         val param = if (testName != null) "--tests $testName" else ""
-        val gradleCommand = "${gradleData.data.id}:${project.service.settings.verifySnapshotsCommand}"
+        val gradleTask = project.service.settings.verifySnapshotsCommand
         val scriptParams = project.service.settings.verifyScriptParams
+        val command = if (moduleId != null) {
+            "$moduleId:$gradleTask $param"
+        } else {
+            "$gradleTask $param"
+        }.trim()
         runGradle(
             project,
             path,
-            "$gradleCommand $param",
+            command,
             scriptParams,
             VerifyTaskCallback(project, psiClass, psiMethod)
         )

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/group/GroupRecordAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/group/GroupRecordAction.kt
@@ -2,6 +2,7 @@ package com.getyourguide.paparazzi.actions.group
 
 import com.getyourguide.paparazzi.actions.RecordTaskCallback
 import com.getyourguide.paparazzi.file
+import com.getyourguide.paparazzi.getModuleId
 import com.getyourguide.paparazzi.getProjectPath
 import com.getyourguide.paparazzi.gradleModuleData
 import com.getyourguide.paparazzi.markers.getQualifiedTestName
@@ -27,7 +28,7 @@ class GroupRecordAction : GroupAction(ACTION_NAME, AllIcons.Debugger.Db_set_brea
             val testName = getQualifiedTestName(psiClass, null)
             runRecordTask(
                 project = project,
-                moduleId = gradleData.data.id,
+                moduleId = gradleData.getModuleId(),
                 testName = testName,
                 projectPath = projectPath,
                 callback = RecordTaskCallback(project, psiClass, null)
@@ -42,7 +43,7 @@ class GroupRecordAction : GroupAction(ACTION_NAME, AllIcons.Debugger.Db_set_brea
             val testName = psiPackage.qualifiedName + ".*"
             runRecordTask(
                 project = project,
-                moduleId = gradleData.data.id,
+                moduleId = gradleData.getModuleId(),
                 testName = testName,
                 projectPath = projectPath,
             )
@@ -54,7 +55,7 @@ class GroupRecordAction : GroupAction(ACTION_NAME, AllIcons.Debugger.Db_set_brea
             val projectPath = gradleData.getProjectPath() ?: project.basePath ?: return
             runRecordTask(
                 project = project,
-                moduleId = gradleData.data.id,
+                moduleId = gradleData.getModuleId(),
                 testName = null,
                 projectPath = projectPath,
             )
@@ -64,7 +65,7 @@ class GroupRecordAction : GroupAction(ACTION_NAME, AllIcons.Debugger.Db_set_brea
 
     private fun runRecordTask(
         project: Project,
-        moduleId: String,
+        moduleId: String?,
         testName: String?,
         projectPath: String,
         callback: RecordTaskCallback? = null,
@@ -72,10 +73,15 @@ class GroupRecordAction : GroupAction(ACTION_NAME, AllIcons.Debugger.Db_set_brea
         val gradleCommand = project.service.settings.recordSnapshotsCommand
         val scriptParams = project.service.settings.recordScriptParams
         val filters = if (testName != null) "--tests $testName" else ""
+        val command = if (moduleId != null) {
+            "$moduleId:$gradleCommand $filters"
+        } else {
+            "$gradleCommand $filters"
+        }.trim()
         runGradle(
             project,
             projectPath,
-            "$moduleId:$gradleCommand $filters",
+            command,
             scriptParams,
             callback
         )

--- a/src/main/kotlin/com/getyourguide/paparazzi/gradle/GradleSystemListener.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/gradle/GradleSystemListener.kt
@@ -1,0 +1,28 @@
+package com.getyourguide.paparazzi.gradle
+
+import com.getyourguide.paparazzi.service.service
+import java.lang.Exception
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListenerAdapter
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskType.RESOLVE_PROJECT
+import org.jetbrains.kotlin.idea.configuration.GRADLE_SYSTEM_ID
+
+class GradleSystemListener : ExternalSystemTaskNotificationListenerAdapter() {
+
+    override fun onSuccess(id: ExternalSystemTaskId) {
+        super.onSuccess(id)
+        if (id.projectSystemId == GRADLE_SYSTEM_ID && id.type == RESOLVE_PROJECT) {
+            id.findProject()?.let { project ->
+                project.service.loadFromSelectedEditor(fullRefresh = true)
+            }
+        }
+    }
+
+    override fun onFailure(id: ExternalSystemTaskId, e: Exception) {
+        if (id.projectSystemId == GRADLE_SYSTEM_ID && id.type == RESOLVE_PROJECT) {
+            id.findProject()?.let { project ->
+                project.service.loadFromSelectedEditor(fullRefresh = true)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/getyourguide/paparazzi/markers/PaparazziRunLineMarkerContributor.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/markers/PaparazziRunLineMarkerContributor.kt
@@ -5,6 +5,7 @@ import com.getyourguide.paparazzi.actions.RecordPaparazziAction
 import com.getyourguide.paparazzi.actions.VerifyPaparazziAction
 import com.getyourguide.paparazzi.containingUClass
 import com.getyourguide.paparazzi.isPaparazziClass
+import com.getyourguide.paparazzi.isParametrizedTest
 import com.intellij.codeInsight.TestFrameworks
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
@@ -86,6 +87,7 @@ class PaparazziRunLineMarkerContributor : RunLineMarkerContributor() {
     private fun PsiElement.isPaparazziTestClass(): Boolean {
         val uClass = containingUClass()
         if (uClass != null) {
+
             if (uClass.isPaparazziClass()) return true
         }
         return false
@@ -95,12 +97,14 @@ class PaparazziRunLineMarkerContributor : RunLineMarkerContributor() {
 internal fun getQualifiedTestName(psiClass: PsiClass, psiMethod: PsiMethod?): String? {
     val className = psiClass.qualifiedName
     if (className != null) {
-        val methodName = psiMethod?.name
+        var methodName = psiMethod?.name
+        if (isParametrizedTest(psiClass, psiMethod) && methodName != null) {
+            methodName += "[*]"
+        }
         return if (methodName != null) "$className.$methodName" else className
     }
     return null
 }
-
 internal fun runGradle(
     project: Project,
     path: String,

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -60,6 +60,8 @@
     <depends>com.intellij.gradle</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <externalSystemTaskNotificationListener
+            implementation="com.getyourguide.paparazzi.gradle.GradleSystemListener"/>
         <toolWindow factoryClass="com.getyourguide.paparazzi.PaparazziWindow" id="Paparazzi" anchor="right"
                     icon="/icons/icon.svg"/>
         <projectService serviceInterface="com.getyourguide.paparazzi.service.MainService"


### PR DESCRIPTION
## About

This PR introduces a new way to query for a module location in the IDEA file structure. It also updates the way tasks are run, using module IDs for gradle tasks instead of using module dir as a project dir, to be more in line with the way IntelliJ runs tests in multimodular projects.

Also, it includes a tiny fix to detect parametrized tests, updating the filter definition logic for a single parametrized test run. 

## Problem

In our project, most modules used with Paparazzi are nested, which causes the default module path resolution logic to fail. Let's say we have this module tree:
```
Project
|- app
|- design-system
   |- component-one
   |- component-two
```
As a result, the plugin thinks that the module directory for the Gradle module `:design-system:component-one` is `$projectDir/design-system`. Because the default module lookup logic is faulty, checking if the file or dir is inside the `.idea/modules` dir is not helping either.

To go around this, the updated plugin now queries `ModuleData` before searching for snapshots or executing Gradle external actions.