### PR TITLE
Fix modulePath in a nested module

### DIFF
--- a/src/main/kotlin/com/getyourguide/paparazzi/Utils.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/Utils.kt
@@ -64,7 +64,7 @@ internal fun Project.modulePath(file: VirtualFile): String? {
     return modules.asSequence().map { it.getModuleDir() }.firstOrNull { file.path.startsWith(it) }
         ?: basePath?.let { projectPath ->
             val relativePath = FileUtil.getRelativePath(projectPath, file.path, File.separatorChar)
-            val moduleName = relativePath?.split(File.separator)?.firstOrNull()
+            val moduleName = relativePath?.substringBefore("/src")
             if (moduleName != null) projectPath + File.separator + moduleName else null
         }
 }


### PR DESCRIPTION
When running on nested module setup `modules.asSequence().map { it.getModuleDir() }.firstOrNull { file.path.startsWith(it) }` was never called and it was always fallbacking to `basePath?.let { projectPath -> ...` But it does not support nested module setup, this should fix it. All test files usually are located inside the `src` folder and the src folder is the child folder of a module.