### PR TITLE
Support for IntelliJ iDEA 2024.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.gradle
 /.idea
 /build
+/.intellijPlatform

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,33 +1,36 @@
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.9.10" // https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
-    id("org.jetbrains.intellij") version "1.17.2"
+    id("org.jetbrains.kotlin.jvm") version "1.9.24" // https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
+    id("org.jetbrains.intellij.platform") version "2.0.1" // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html
 }
 
 group = "com.getyourguide"
-version = "1.2.2023.3"
+version = "1.2.2024.2"
+
+val ideaVersion = "2024.2"
 
 repositories {
     mavenCentral()
+
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
-// Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-intellij {
-    version.set("2023.3")
-    plugins.set(listOf("Kotlin", "java", "gradle"))
+dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity(ideaVersion)
+        bundledPlugins("org.jetbrains.kotlin", "com.intellij.java", "com.intellij.gradle")
 
-    tasks {
-        buildSearchableOptions {
-            enabled = false
-        }
+        pluginVerifier()
+        zipSigner()
+        instrumentationTools()
     }
 }
 
 tasks {
     runIde {
-        // Absolute path to installed target Android Studio to use as
-        // IDE Development Instance (the "Contents" directory is macOS specific):
-        ideDir.set(file("/Applications/Android Studio.app/Contents"))
+        jvmArgs("-Xmx1g")
     }
     // Set the JVM compatibility versions
     withType<JavaCompile> {
@@ -39,8 +42,8 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("231")
-        untilBuild.set("233.*")
+        sinceBuild.set("241")
+        untilBuild.set("242.*")
     }
 
     signPlugin {

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/ActualSizeAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/ActualSizeAction.kt
@@ -1,6 +1,7 @@
 package com.getyourguide.paparazzi.actions
 
 import com.getyourguide.paparazzi.service.service
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 
@@ -17,4 +18,6 @@ class ActualSizeAction : AnAction() {
         val project = e.project ?: return
         e.presentation.isEnabled = project.service.settings.isFitToWindow
     }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/AutoLoadFileAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/AutoLoadFileAction.kt
@@ -1,6 +1,7 @@
 package com.getyourguide.paparazzi.actions
 
 import com.getyourguide.paparazzi.service.service
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 
@@ -20,4 +21,6 @@ class AutoLoadFileAction : ToggleAction() {
         project.service.isAutoLoadFileEnabled = state
         if (state) project.service.loadFromSelectedEditor(false)
     }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/AutoLoadMethodAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/AutoLoadMethodAction.kt
@@ -1,6 +1,7 @@
 package com.getyourguide.paparazzi.actions
 
 import com.getyourguide.paparazzi.service.service
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 
@@ -20,4 +21,6 @@ class AutoLoadMethodAction : ToggleAction() {
         project.service.isAutoLoadMethodEnabled = state
         if (state) project.service.loadFromSelectedEditor(false)
     }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/DeleteFileAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/DeleteFileAction.kt
@@ -4,6 +4,7 @@ import com.getyourguide.paparazzi.service.service
 import com.getyourguide.paparazzi.service.toFileInfo
 import com.intellij.icons.AllIcons
 import com.intellij.ide.util.DeleteHandler
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
@@ -38,6 +39,8 @@ class DeleteFileAction(
             deleteSnapshots(project, files)
         }
     }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }
 
 internal fun deleteSnapshots(project: Project, files: List<VirtualFile>) {

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/FitZoomToWindowAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/FitZoomToWindowAction.kt
@@ -1,6 +1,7 @@
 package com.getyourguide.paparazzi.actions
 
 import com.getyourguide.paparazzi.service.service
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 
@@ -17,4 +18,6 @@ class FitZoomToWindowAction : AnAction() {
         val project = e.project ?: return
         e.presentation.isEnabled = !project.service.settings.isFitToWindow
     }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/OpenFileAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/OpenFileAction.kt
@@ -1,5 +1,6 @@
 package com.getyourguide.paparazzi.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -19,4 +20,6 @@ class OpenFileAction(val file: VirtualFile) : AnAction(ACTION_NAME) {
             fileManager.openFile(file, false)
         }
     }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/RecordPaparazziAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/RecordPaparazziAction.kt
@@ -6,6 +6,7 @@ import com.getyourguide.paparazzi.markers.runGradle
 import com.getyourguide.paparazzi.modulePath
 import com.getyourguide.paparazzi.service.service
 import com.intellij.icons.AllIcons.Debugger.Db_set_breakpoint
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.externalSystem.task.TaskCallback
@@ -41,6 +42,8 @@ class RecordPaparazziAction(private val psiClass: PsiClass, private val psiMetho
             RecordTaskCallback(project, psiClass, psiMethod)
         )
     }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }
 
 internal class RecordTaskCallback(

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/RefreshAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/RefreshAction.kt
@@ -1,6 +1,7 @@
 package com.getyourguide.paparazzi.actions
 
 import com.getyourguide.paparazzi.service.service
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 
@@ -12,4 +13,6 @@ class RefreshAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         e.project?.service?.loadFromSelectedEditor(true)
     }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/ShowErrorsAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/ShowErrorsAction.kt
@@ -1,6 +1,7 @@
 package com.getyourguide.paparazzi.actions
 
 import com.getyourguide.paparazzi.service.service
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 
@@ -20,4 +21,6 @@ class ShowErrorsAction : ToggleAction() {
         project.service.onlyShowFailures = state
         project.service.loadFromSelectedEditor(false)
     }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/VerifyPaparazziAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/VerifyPaparazziAction.kt
@@ -8,6 +8,7 @@ import com.getyourguide.paparazzi.nonBlocking
 import com.getyourguide.paparazzi.service.service
 import com.getyourguide.paparazzi.service.toFileInfo
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.WriteAction
@@ -44,6 +45,8 @@ class VerifyPaparazziAction(private val psiClass: PsiClass, private val psiMetho
             VerifyTaskCallback(project, psiClass, psiMethod)
         )
     }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }
 
 internal class VerifyTaskCallback(

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/ZoomInAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/ZoomInAction.kt
@@ -1,5 +1,6 @@
 package com.getyourguide.paparazzi.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 
@@ -12,4 +13,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 class ZoomInAction : AnAction() {
 
     override fun actionPerformed(e: AnActionEvent) = Unit
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }

--- a/src/main/kotlin/com/getyourguide/paparazzi/actions/ZoomOutAction.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/actions/ZoomOutAction.kt
@@ -1,5 +1,6 @@
 package com.getyourguide.paparazzi.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 
@@ -12,4 +13,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 class ZoomOutAction : AnAction() {
 
     override fun actionPerformed(e: AnActionEvent) = Unit
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }


### PR DESCRIPTION
Adding support for IDE 2024.2

- `KtFile.classes` doesn't return classes. So had to tweak a bit.
- 2024.2 uses Gradle Plugin 2.0. So the build script is significantly modified.
- AnAction should now always override `getActionUpdateThread()`.

Tested in older versions and the latest version 2024.2.2. But setting the minVersion to 241. Going forward, new updates (in feature) will be supported only for 2024 and onwards only. It's hard to keep supporting older version with too many deprecations and api removals.