### PR TITLE
[Auto-PR] Adding Repository Maintenance workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,24 @@
+name: Dependency Submission
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  maintenance_workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4.2.1
+      - uses: actions/setup-java@v4.4.0
+        name: Setup Java
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v4.1.0
+        with:
+          gradle-version: wrapper
+          dependency-graph: generate-and-submit
+          # Include only relevant configurations
+          dependency-graph-include-configurations: '(implementation|api|compileClasspath|runtimeClasspath)'


### PR DESCRIPTION
### Description

This PR adds a repository maintenance workflow, which contains a step to publish dependencies from gradle services to GitHub API. This enabled reporting of security vulnerabilities in dependencies.

It also contains additional steps, therefore you can remove those ones from the existing workflows.
* credential-scan
* dependency-submission
* validate catalog-info

Please merge the PR and keep an eye on the security alerts. If you have any questions, feel free to reach out to #guild-java. 

This PR will be automatically merged in a week if not actioned.