### PR TITLE
Support module nesting and improve backward compatibility for newer IDE versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,10 @@ tasks {
     buildSearchableOptions {
         enabled = false
     }
+
+    prepareJarSearchableOptions {
+        enabled = false
+    }
 }
 
 intellijPlatformTesting {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@
 
 pluginGroup = com.getyourguide
 pluginName = Paparazzi
-pluginVersion = 1.2.2024.3
+pluginVersion = 1.2.2025.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243
-pluginUntilBuild = 243.*
+pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-platformVersion = 2024.3
+platformVersion = 2024.3.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/src/main/kotlin/com/getyourguide/paparazzi/Utils.kt
+++ b/src/main/kotlin/com/getyourguide/paparazzi/Utils.kt
@@ -65,7 +65,7 @@ internal fun VirtualFile.methods(project: Project): List<String> {
 internal fun Project.modulePath(file: VirtualFile): String? {
     return basePath?.let { projectPath ->
             val relativePath = FileUtil.getRelativePath(projectPath, file.path, File.separatorChar)
-            val moduleName = relativePath?.split(File.separator)?.firstOrNull()
+            val moduleName = relativePath?.substringBefore("/src")
             if (moduleName != null) projectPath + File.separator + moduleName else null
         }
 }


### PR DESCRIPTION
Current Gradle settings limit the number of versions supported (`pluginUntilBuild`), forcing a new plugin version for every single IDE version that is released. This is not necessary, instead we can use `pluginSinceBuild` to set the minimum supported version and no compatibility breaks will ever be introduced unless IntelliJ breaks compatibility.

Additionally, a second commit introduces a fix for the support of nested modules, mentioned on issue #14 and already pushed before by closed in PR #15 